### PR TITLE
Add the day to the schedule

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -1,6 +1,10 @@
 # Voices from the Global Open Science Community: Showcasing Progress, Challenges, and Lessons Learned
 
-Welcome to the JupyterBook for  "INV51D - Voices from the Global Open Science Community: Showcasing Progress, Challenges, and Lessons Learned". View the source code for this site at https://github.com/agu-openscience-innovations/jupyterbook-2023. Speakers are welcome (and encouraged!) to submit their own content via Pull Request.
+Welcome to the JupyterBook for the session "INV51D - Voices from the Global Open Science Community: Showcasing Progress, Challenges, and Lessons Learned" at the 2023 AGU Fall Meeting. 
+
+View the source code for this site at https://github.com/agu-openscience-innovations/jupyterbook-2023. 
+
+**Speakers are welcome (and encouraged!) to submit their own content via Pull Request.**
 
 ```{tableofcontents}
 ```

--- a/schedule.md
+++ b/schedule.md
@@ -9,7 +9,7 @@ kernelspec:
     name: python3
 ---
 # Schedule
-## Day TBD
+## Friday, December 8, 2023
 
 **8:30 - 10:00 - [Oral talks + discussion](./speaker_content/01-morning-oral-session/00-overview.md)**
 * 5x10-minute talks + ~40-min discussion


### PR DESCRIPTION
Minor updates:
- add day to schedule page
- add that this session is at the 2023 AGU Fall Meeting on the main page